### PR TITLE
fixed table alignment when sidebar closes

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -1,42 +1,50 @@
-
-
 .app-nav {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    position: unset!important;
-    margin-top: 16px!important;
-    margin-right: unset!important;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: unset !important;
+  margin-top: 16px !important;
+  margin-right: unset !important;
+}
+
+#docsify-darklight-theme {
+  right: -5px;
+  top: -5px;
+}
+
+body.ready.sticky main section.content {
+  display: flex;
+  justify-content: center;
 }
 
 @media screen and (max-width: 480px) {
-    .app-nav {
-        margin-right: 0!important; 
-    }
+  .app-nav {
+    margin-right: 0 !important;
+  }
 }
 
 @media only screen and (max-width: 930px) and (min-width: 755px) {
-    .app-nav {
-        width: 100%; 
-        margin-right: 0!important; 
-    }
+  .app-nav {
+    width: 100%;
+    margin-right: 0 !important;
+  }
 }
 
 @media only screen and (max-width: 385px) and (min-width: 306px) {
-    .app-nav {
-        text-align: center !important;
-    }
+  .app-nav {
+    text-align: center !important;
+  }
 }
 
 /* Main section styling */
 
 .content {
-    padding-top: 16px !important; /* Add some padding to the top of the content */
+  padding-top: 16px !important; /* Add some padding to the top of the content */
 }
 
 /* Additional adjustments for smaller screens */
 @media screen and (max-width: 480px) {
-    .content {
-        padding-top: 8px !important; /* Reduce the padding on smaller screens */
-    }
+  .content {
+    padding-top: 8px !important; /* Reduce the padding on smaller screens */
+  }
 }


### PR DESCRIPTION
# 🛠️ Fixes issue #182 
# 📇 Changes proposed: The alignment of the table is fixed when the sidebar collapses. The day-night icon doesn't collide with the table anymore
# ✅ Check List (Mark all the applicable boxes)
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [ ] This PR contains changes in the documentation
- [x] This PR contains changes in the Code of the project
- [x] The title of my pull request is a short description of the requested changes.

## 📄 Note to reviewers
-It's a UI fix, for the issue that I proposed.

## 📷 Screenshots
![Screenshot (215)](https://github.com/hasnainmakada-99/Open-Source-With-Hasnain/assets/121796450/9479a8bf-7319-4b63-9db2-03d6db05b5d3)


![Screenshot (216)](https://github.com/hasnainmakada-99/Open-Source-With-Hasnain/assets/121796450/92e14853-d49a-48b8-9110-b207d9a1d8e8)
